### PR TITLE
Add Vue 3 crypto dashboard skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=https://api.coingecko.com/api/v3

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-"# crypto-vue-dashboard" 
+# Crypto Vue Dashboard
+
+A professional and animated cryptocurrency dashboard built with Vue.js 3, showing real-time crypto prices and variation charts using the CoinGecko API and ApexCharts.
+
+## \ud83d\ude80 Features
+
+- Real-time cryptocurrency prices
+- Interactive price charts
+- Responsive and modern UI with smooth animations
+- Built using Vue 3 Composition API + TailwindCSS
+- Future-ready structure for authentication system
+
+## \ud83d\udcbb Tech Stack
+
+- Vue 3
+- Vite
+- TailwindCSS
+- ApexCharts
+- Axios
+- CoinGecko API
+
+## \ud83d\udce6 Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/VictorRabelo/crypto-vue-dashboard.git
+cd crypto-vue-dashboard
+
+# Install dependencies
+npm install
+
+# Run the app
+npm run dev
+```
+
+## \ud83d\udcf8 Preview
+
+Screenshots coming soon.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Crypto Dashboard</title>
+    <link rel="stylesheet" href="/src/style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "crypto-vue-dashboard",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "axios": "^1.6.0",
+    "apexcharts": "^3.49.0",
+    "vue3-apexcharts": "^1.4.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-vue": "^5.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.0",
+    "autoprefixer": "^10.4.0",
+    "animate.css": "^4.1.1"
+  }
+}
+

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,3 @@
+<template>
+  <router-view />
+</template>

--- a/src/auth/authService.js
+++ b/src/auth/authService.js
@@ -1,0 +1,15 @@
+let token = null
+
+export function login(username, password) {
+  // Dummy login logic
+  token = 'dummy-token'
+  return Promise.resolve(token)
+}
+
+export function logout() {
+  token = null
+}
+
+export function isAuthenticated() {
+  return !!token
+}

--- a/src/components/ChartComponent.vue
+++ b/src/components/ChartComponent.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="mt-8">
+    <apexchart type="line" height="350" :options="chartOptions" :series="series" />
+  </div>
+</template>
+
+<script setup>
+import { ref, watch, onMounted } from 'vue'
+import api from '../services/api'
+import VueApexCharts from 'vue3-apexcharts'
+
+const props = defineProps({
+  coin: String,
+})
+const series = ref([{ data: [] }])
+const chartOptions = ref({
+  chart: { id: 'prices' },
+  xaxis: { categories: [] },
+})
+
+const loadChart = async () => {
+  const data = await api.getCoinChart(props.coin)
+  series.value = [{ data: data.prices.map(p => p[1]) }]
+  chartOptions.value.xaxis.categories = data.prices.map(p => new Date(p[0]).toLocaleDateString())
+}
+
+watch(() => props.coin, loadChart, { immediate: true })
+onMounted(() => loadChart())
+</script>

--- a/src/components/CryptoList.vue
+++ b/src/components/CryptoList.vue
@@ -1,0 +1,40 @@
+<template>
+  <div>
+    <table class="table-auto w-full text-left">
+      <thead>
+        <tr>
+          <th class="px-2 py-1">Name</th>
+          <th class="px-2 py-1">Price</th>
+          <th class="px-2 py-1">Market Cap</th>
+          <th class="px-2 py-1">Volume</th>
+          <th class="px-2 py-1">Change %</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="coin in coins" :key="coin.id" class="hover:bg-gray-100 cursor-pointer" @click="$emit('selectCoin', coin.id)">
+          <td class="px-2 py-1">{{ coin.name }}</td>
+          <td class="px-2 py-1">${{ coin.current_price.toLocaleString() }}</td>
+          <td class="px-2 py-1">${{ coin.market_cap.toLocaleString() }}</td>
+          <td class="px-2 py-1">${{ coin.total_volume.toLocaleString() }}</td>
+          <td class="px-2 py-1" :class="coin.price_change_percentage_24h >= 0 ? 'text-green-500' : 'text-red-500'">
+            {{ coin.price_change_percentage_24h.toFixed(2) }}%
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '../services/api'
+
+const coins = ref([])
+const fetchData = async () => {
+  coins.value = await api.getMarketData()
+}
+onMounted(() => {
+  fetchData()
+  setInterval(fetchData, 30000)
+})
+</script>

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -1,0 +1,19 @@
+<template>
+  <form @submit.prevent="handleLogin" class="space-y-4">
+    <input v-model="username" type="text" placeholder="Username" class="w-full p-2 border" />
+    <input v-model="password" type="password" placeholder="Password" class="w-full p-2 border" />
+    <button class="bg-blue-500 text-white px-4 py-2" type="submit">Login</button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { login } from '../auth/authService'
+
+const username = ref('')
+const password = ref('')
+
+async function handleLogin() {
+  await login(username.value, password.value)
+}
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,11 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import router from './router'
+import VueApexCharts from 'vue3-apexcharts'
+import './style.css'
+import 'animate.css'
+
+createApp(App)
+  .use(router)
+  .use(VueApexCharts)
+  .mount('#app')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,0 +1,15 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import Dashboard from '../views/Dashboard.vue'
+import Login from '../views/Login.vue'
+
+const routes = [
+  { path: '/', name: 'Dashboard', component: Dashboard },
+  { path: '/login', name: 'Login', component: Login },
+]
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes,
+})
+
+export default router

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,29 @@
+import axios from 'axios'
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL || 'https://api.coingecko.com/api/v3',
+})
+
+export default {
+  async getMarketData() {
+    const response = await apiClient.get('/coins/markets', {
+      params: {
+        vs_currency: 'usd',
+        order: 'market_cap_desc',
+        per_page: 10,
+        page: 1,
+        price_change_percentage: '24h',
+      },
+    })
+    return response.data
+  },
+  async getCoinChart(coin) {
+    const response = await apiClient.get(`/coins/${coin}/market_chart`, {
+      params: {
+        vs_currency: 'usd',
+        days: 7,
+      },
+    })
+    return response.data
+  },
+}

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">Crypto Dashboard</h1>
+    <CryptoList @selectCoin="updateCoin" />
+    <ChartComponent :coin="selectedCoin" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import CryptoList from '../components/CryptoList.vue'
+import ChartComponent from '../components/ChartComponent.vue'
+
+const selectedCoin = ref('bitcoin')
+function updateCoin(coin) {
+  selectedCoin.value = coin
+}
+</script>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="container mx-auto p-4 max-w-md">
+    <h1 class="text-2xl font-bold mb-4">Login</h1>
+    <LoginForm />
+  </div>
+</template>
+
+<script setup>
+import LoginForm from '../components/LoginForm.vue'
+</script>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{vue,js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+export default defineConfig({
+  plugins: [vue()],
+})


### PR DESCRIPTION
## Summary
- initialize vite-powered Vue 3 dashboard project
- add TailwindCSS config, PostCSS config and Vite config
- implement components and views for crypto list, charts and login
- add simple auth service with dummy token logic
- document project usage and stack

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5731af5483279d404d40579bc50f